### PR TITLE
Fixed JSON blocks are incorrectly formatted. #28

### DIFF
--- a/Source/Language/Json.js
+++ b/Source/Language/Json.js
@@ -32,7 +32,7 @@ EJS.Language.json = new Class({
                 alias: 'kw1'
             },
             'strings': {
-                pattern: this.common.strings,
+                pattern: /('[^'\\\r\n]*(?:\\.[^'\\\r\n]*)*'|"[^"\\\r\n]*(?:\\.[^"\\\r\n]*)*")\s*[,\]}]+/gi,
                 alias:   'st0'
             },
             'brackets': {


### PR DESCRIPTION
This pull request changes how JSON string values are parsed and fixes issues which caused the browser to highlight JSON keys instead of values only.