### PR TITLE
a11y: Update droide theme contrast

### DIFF
--- a/src/themes/droide.less
+++ b/src/themes/droide.less
@@ -209,25 +209,25 @@
 
     // numbers
     .TOKEN(n0, {
-        color: #009999;
+        color: #007f7f;
     });
     .TOKEN(n1, {
-        color: #009999;
+        color: #007f7f;
     });
     .TOKEN(n2, {
-        color: #009999;
+        color: #007f7f;
         font-style: italic;
     });
     .TOKEN(n3, {
-        color: #009999;
+        color: #007f7f;
         font-style: italic;
     });
     .TOKEN(n4, {
-        color: #009999;
+        color: #007f7f;
         font-style: italic;
     });
     .TOKEN(n5, {
-        color: #009999;
+        color: #007f7f;
         text-decoration: underline;
     });
 
@@ -308,10 +308,10 @@
         color: #445588;
     });
     .TOKEN(x13, {
-        color: #009999;
+        color: #007f7f;
     });
     .TOKEN(x14, {
-        color: #009999;
+        color: #007f7f;
     });
     .TOKEN(x15, {
         color: #990073;


### PR DESCRIPTION
This PR makes a very subtle change to the theme, changing any instance of #009999 to #007f7f. This passes the WCAG requirement to be above a contrast threshold. Unclear if the theme is inaccessible in other ways.