### PR TITLE
Spelling mistake of "MariaDB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Features
 * **LESS** (less)
 * **lighttpd** (lighttpd)
 * **LUA** (lua)
-* **MariadDB** (mariadb)
+* **MariaDB** (mariadb)
 * **Markdown** (gfm, md, markdown)
 * **Matlab/Octave** (octave, matlab)
 * **MSSQL** (mssql)


### PR DESCRIPTION
## The spelling of "MariaDB" is written as "MariadDB".